### PR TITLE
feat: add pre-commit hooks style and spellcheck

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,28 @@
+ci:
+  autoupdate_commit_msg: "chore: update pre-commit hooks"
+  autofix_commit_msg: "style: pre-commit fixes"
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.2.4
+    hooks:
+      - id: codespell
+        exclude: >
+            (?x)^(
+                .*\.html
+            )$
+


### PR DESCRIPTION
Added pre-commit hooks to standardized code style and run basic spell checking. This can be part of PR checks.

To execute manually:

```sh
$  pre-commit run --all-files
```
Sample result:

![image](https://github.com/ogbinar/DataEngineeringPilipinas/assets/111378/248796b9-f6c8-4d91-ac99-43d848b2cb48)
